### PR TITLE
Introducing Save Behavior for DynamoDB Mapper Config

### DIFF
--- a/src/main/java/com/salessparrow/api/config/DynamoDBConfiguration.java
+++ b/src/main/java/com/salessparrow/api/config/DynamoDBConfiguration.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.SaveBehavior;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +19,6 @@ import org.springframework.context.annotation.Configuration;
 public class DynamoDBConfiguration {
 
     Logger logger = LoggerFactory.getLogger(DynamoDBConfiguration.class);
-
 
     @Value("${aws.dynamodb.endpoint}")
     private String dynamodbEndpoint;
@@ -32,12 +32,11 @@ public class DynamoDBConfiguration {
     @Value("${aws.dynamodb.secretKey}")
     private String dynamodbSecretKey;
 
-
     @Bean
     public DynamoDBMapper dynamoDBMapper() {
         DynamoDBMapper defaultMapper = new DynamoDBMapper(buildAmazonDynamoDB(), dynamoDBMapperConfig());
-        
-        //Override DynamoDb operations to add logging.
+
+        // Override DynamoDb operations to add logging.
         return new DynamoDBMapper(buildAmazonDynamoDB(), dynamoDBMapperConfig()) {
 
             @Override
@@ -51,7 +50,8 @@ public class DynamoDBConfiguration {
                 logger.debug("DBQuery:Save: table-{}", object.getClass().getSimpleName());
                 defaultMapper.save(object);
             }
-            // Similarly, you can override other used methods like delete, batchSave, etc. similarly
+            // Similarly, you can override other used methods like delete, batchSave, etc.
+            // similarly
         };
     }
 
@@ -60,9 +60,9 @@ public class DynamoDBConfiguration {
         return AmazonDynamoDBClientBuilder
                 .standard()
                 .withEndpointConfiguration(
-                   new AwsClientBuilder.EndpointConfiguration(dynamodbEndpoint,awsRegion))
+                        new AwsClientBuilder.EndpointConfiguration(dynamodbEndpoint, awsRegion))
                 .withCredentials(new AWSStaticCredentialsProvider(
-                   new BasicAWSCredentials(dynamodbAccessKey,dynamodbSecretKey)))
+                        new BasicAWSCredentials(dynamodbAccessKey, dynamodbSecretKey)))
                 .build();
     }
 
@@ -71,7 +71,7 @@ public class DynamoDBConfiguration {
         String prefix = CoreConstants.environment() + "_";
         return new DynamoDBMapperConfig.Builder()
                 .withTableNameOverride(DynamoDBMapperConfig.TableNameOverride.withTableNamePrefix(prefix))
+                .withSaveBehavior(SaveBehavior.UPDATE_SKIP_NULL_ATTRIBUTES)
                 .build();
     }
 }
-


### PR DESCRIPTION
Implemented the use of the `UPDATE_SKIP_NULL_ATTRIBUTES` save behaviour for upserting data within a table during the save process. This enhancement ensures that null attributes are skipped during the upsert operation, maintaining existing values unchanged while updating relevant non-key attributes.